### PR TITLE
Add spot data to Database

### DIFF
--- a/adrilight/Settings/DeviceSettings.cs
+++ b/adrilight/Settings/DeviceSettings.cs
@@ -1,4 +1,5 @@
-﻿using GalaSoft.MvvmLight;
+﻿using adrilight.Spots;
+using GalaSoft.MvvmLight;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -123,7 +124,10 @@ namespace adrilight
         private Color _mcolor13 = Color.FromArgb(0, 0, 255, 255);
         private Color _mcolor14 = Color.FromArgb(0, 0, 255, 255);
         private Color _mcolor15 = Color.FromArgb(0, 0, 255, 255);
-
+        private IDeviceSpot[] _spots = new DeviceSpot[] { new DeviceSpot(0, 0,25,25,0,0),
+                                                          new DeviceSpot(0,0,25,25,0,0),
+                                                          new DeviceSpot(0, 0,25,25,0,0),
+                                                          new DeviceSpot(0,0,25,25,0,0),};
 
 
 
@@ -156,7 +160,7 @@ namespace adrilight
 
 
         public int OutputLocation { get => _outputLocation; set { Set(() => OutputLocation, ref _outputLocation, value); } }
-
+        public IDeviceSpot[] Spots { get => _spots; set { Set(() => Spots, ref _spots, value); } }
         public int MSens { get => _mSens; set { Set(() => MSens, ref _mSens, value); } }
        // public bool Autostart { get => _autostart; set { Set(() => Autostart, ref _autostart, value); } }
         public int BorderDistanceX { get => _borderDistanceX; set { Set(() => BorderDistanceX, ref _borderDistanceX, value); } }

--- a/adrilight/Settings/IDeviceSettings.cs
+++ b/adrilight/Settings/IDeviceSettings.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using adrilight.Spots;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -54,7 +55,7 @@ namespace adrilight
         Guid InstallationId { get; set; }
         bool IsHUB { get; set; }
         bool LEDOn { get; set; }
-
+        IDeviceSpot[] Spots { get; set; }
        
 
         byte Brightness { get; set; }

--- a/adrilight/Settings/ILEDSettings.cs
+++ b/adrilight/Settings/ILEDSettings.cs
@@ -1,0 +1,19 @@
+﻿using adrilight.Spots;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace adrilight
+{
+    public interface ILEDSettings
+    {
+        int DeviceID { get; set; }
+        string DeviceSerial { get; set; }
+        IDeviceSpot Spot0 { get; set; }
+
+       
+
+    }
+}

--- a/adrilight/Settings/LEDSettings.cs
+++ b/adrilight/Settings/LEDSettings.cs
@@ -1,0 +1,24 @@
+﻿using adrilight.Spots;
+using GalaSoft.MvvmLight;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace adrilight
+{
+    internal class LEDSettings : ViewModelBase, ILEDSettings
+    {
+        private int _deviceID = 1;
+        private IDeviceSpot _spot0 = null;
+        private string _deviceSerial = "151293";
+
+
+
+        public int DeviceID { get => _deviceID; set { Set(() => DeviceID, ref _deviceID, value); } }
+        public IDeviceSpot Spot0 { get => _spot0; set { Set(() => Spot0, ref _spot0, value); } }
+        public string DeviceSerial { get => _deviceSerial; set { Set(() => DeviceSerial, ref _deviceSerial, value); } }
+
+    }
+}

--- a/adrilight/Spots/DeviceSpotSet.cs
+++ b/adrilight/Spots/DeviceSpotSet.cs
@@ -121,6 +121,7 @@ namespace adrilight
             lock (Lock)
             {
                 Spots = BuildSpots( DeviceSettings, GeneralSettings);
+                DeviceSettings.Spots = Spots;
             }
         }
 

--- a/adrilight/View/DeviceCanvas.xaml
+++ b/adrilight/View/DeviceCanvas.xaml
@@ -1,0 +1,20 @@
+﻿<UserControl x:Class="adrilight.View.DeviceCanvas"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:adrilight.View"
+             mc:Ignorable="d" 
+             d:DesignHeight="240" d:DesignWidth="320">
+    <Grid>
+        <Canvas 
+            Background="White"
+            AllowDrop="true"
+            Drop="Canvas_Drop"
+            
+            >
+            
+        </Canvas>
+            
+    </Grid>
+</UserControl>

--- a/adrilight/View/DeviceCanvas.xaml.cs
+++ b/adrilight/View/DeviceCanvas.xaml.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace adrilight.View
+{
+    /// <summary>
+    /// Interaction logic for DeviceCanvas.xaml
+    /// </summary>
+    public partial class DeviceCanvas : UserControl
+    {
+        public DeviceCanvas()
+        {
+            InitializeComponent();
+        }
+
+        private void Canvas_Drop(object sender, DragEventArgs e)
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
First step to Support Drag and Drop
Because when implement drag and drop spot feature, the top,left,width,height data must be stored to the database, so end-user doesnt need to config all the spots again everytime they launch the app

old flow : app start, `devicespotset` run `build spot` using minimal value ( `spotX` `spotY`), the problem is we cant and dont want to create multiple algorithm for spot setup styles ( matrix, round, square strip..) because there are infinite posibility of how LEDs are arranged in real life
new flow : app start, first, `devicespotset` still run build spot but using default algorithm for each type of device ( mainly matrix, square, strip) but then user can drag and drop each spot in the device canvas to make it closet to real life setup, or even serve the creative purpose ( to make some effect cooler... I guess), after every `accept` ( or every `drop` action), the `spotset.spots` will save to the `Json database` using same `write json` function

todo: 
- create some default spotsets ( matrix, square , strip)
- Ability to invert the order
- each rectangle has number on it
- dynamicly change the `device canvas` size according to the `device size` in `lighting canvas`
![image](https://user-images.githubusercontent.com/40384831/134785742-f69bc638-087c-4b40-9931-dff12074186c.png)
